### PR TITLE
Add visual diffing for pages

### DIFF
--- a/analyzer.html
+++ b/analyzer.html
@@ -8,7 +8,7 @@
     .hidesource div.source { display: none; }
 
     iframe { width: 100%; height: 40em; padding: 0px; margin: 0px; border: none; }
-    
+
 </style>
 </head>
 
@@ -17,12 +17,12 @@
   <button id="submit" onclick="submit()">Submit</button>
 
   <div id="content"></div>
-  
+
 <script>
 
 /*
 
-Parsing things like this 
+Parsing things like this
 
 !   file:///builds/worker/workspace/build/tests/reftest/tests/layout/reftests/position-sticky/inline-3.html == file:///builds/worker/workspace/build/tests/reftest/tests/layout/reftests/position-sticky/inline-3-ref.html
 */
@@ -37,7 +37,7 @@ function submit() {
         let pair = document.createElement("div");
         pair.classList.add("pair");
         pair.classList.add("hidesource");
-        
+
         let source = document.createElement("button");
         source.innerHTML = "source";
         source.onclick = function() {
@@ -51,7 +51,7 @@ function submit() {
         pair.appendChild(title);
 
         processReftest(test, pair);
-        
+
         content.appendChild(pair);
     }
 }
@@ -64,13 +64,13 @@ function processReftest(input, targetElem) {
       halves = input.split(" != ");
     }
 
-    
+
     let first = localizePath(halves[0], targetElem);
     let second = localizePath(halves[1], targetElem);
 }
 
 function localizePath(input, targetElem) {
-    // example file:///builds/worker/workspace/build/tests/reftest/tests/layout/reftests/position-sticky/inline-3.html 
+    // example file:///builds/worker/workspace/build/tests/reftest/tests/layout/reftests/position-sticky/inline-3.html
     let commonPrefix = "file:///builds/worker/workspace/build/tests/reftest/tests/";
     let parts = input.split(commonPrefix);
     var suffix;
@@ -83,7 +83,7 @@ function localizePath(input, targetElem) {
             console.log("unparseable: "+input);
             suffix = "about:blank";
         } else {
-            suffix = "layout/reftests/" + parts[1].split("/").slice(3).join("/"); 
+            suffix = "layout/reftests/" + parts[1].split("/").slice(3).join("/");
         }
     } else {
         suffix = parts[1];
@@ -98,8 +98,8 @@ function localizePath(input, targetElem) {
     let iframe = document.createElement("iframe");
     iframe.onload = function() {
        let sourceString = "" + iframe.contentDocument.documentElement.outerHTML;
-       source.textContent = sourceString; 
-       // textContent = iframe.contentWindow.document.innerHTML; 
+       source.textContent = sourceString;
+       // textContent = iframe.contentWindow.document.innerHTML;
     }
 
     iframe.src = suffix;

--- a/analyzer.html
+++ b/analyzer.html
@@ -2,7 +2,7 @@
 <head>
 <meta charset="utf-8">
 <style>
-    body { width: 100%;}
+    body { width: 100%; margin: 0; }
     .pair { width: 100%; }
     .test { width: 40%; display: inline-block; }
     .hidesource div.source { display: none; }

--- a/analyzer.html
+++ b/analyzer.html
@@ -38,12 +38,18 @@ function submit() {
         pair.classList.add("pair");
         pair.classList.add("hidesource");
 
-        let source = document.createElement("button");
-        source.innerHTML = "source";
-        source.onclick = function() {
-            pair.classList.toggle("hidesource");
+        let controls = document.createElement("div");
+
+        let showSourceLabel = document.createElement("label");
+        showSourceLabel.textContent = "Show Source";
+        let showSource = document.createElement("input");
+        showSource.type = "checkbox";
+        showSource.onchange = function() {
+            pair.classList.toggle("hidesource", !showSource.checked);
         }
-        pair.appendChild(source);
+        showSourceLabel.appendChild(showSource);
+        controls.appendChild(showSourceLabel);
+        pair.appendChild(controls);
 
         let title = document.createElement("div");
         title.classList.add("testname");

--- a/analyzer.html
+++ b/analyzer.html
@@ -5,6 +5,9 @@
     body { width: 100%; margin: 0; }
     .pair { width: 100%; }
     .test { width: 40%; display: inline-block; }
+    .visual-difference .test {
+        width: 100%; position: absolute; mix-blend-mode: difference; background: white;
+    }
     .hidesource div.source { display: none; }
 
     iframe { width: 100%; height: 40em; padding: 0px; margin: 0px; border: none; }
@@ -49,6 +52,17 @@ function submit() {
         }
         showSourceLabel.appendChild(showSource);
         controls.appendChild(showSourceLabel);
+
+        let showDifferenceLabel = document.createElement("label");
+        showDifferenceLabel.textContent = "Show visual difference";
+        let showDifference = document.createElement("input");
+        showDifference.type = "checkbox";
+        showDifference.onchange = function() {
+            pair.classList.toggle("visual-difference", showDifference.checked);
+        }
+        showDifferenceLabel.appendChild(showDifference);
+        controls.appendChild(showDifferenceLabel);
+
         pair.appendChild(controls);
 
         let title = document.createElement("div");


### PR DESCRIPTION
This uses the `mix-blend-mode: difference;` CSS property to overlay the two pages. I haven't built Firefox, so I can't test it on any real cases, but it works nicely when I just directly set the `src` on the iframes:

<img width="660" alt="screen shot 2017-09-15 at 13 54 51" src="https://user-images.githubusercontent.com/1690225/30496484-81f83b7c-9a1d-11e7-9070-30f66853ac6e.png">
